### PR TITLE
Method for getting Ethereum ERC20 tokens by wallet address

### DIFF
--- a/EthScanNet.Lib/EScanApi/Accounts.cs
+++ b/EthScanNet.Lib/EScanApi/Accounts.cs
@@ -146,5 +146,16 @@ namespace EthScanNet.Lib.EScanApi
             EScanGetTokenBalanceForAccount getTokenBalanceForAccount = new(address, contractAddress, this.Client);
             return await getTokenBalanceForAccount.SendAsync();
         }
+
+        /// <summary>
+        /// Get a list of "ERC20 - Token Transfer Events" by Address
+        /// </summary>
+        /// <param name="address"></param>
+        /// <returns></returns>
+        public async Task<EScanERC20TokenTransferEvents> GetERC20TokenEvents(EScanAddress address)
+        {
+            EScanGetERC20TokenTransferEvents getTokenTransferEvents = new(address, this.Client);
+            return await getTokenTransferEvents.SendAsync();
+        }
     }
 }

--- a/EthScanNet.Lib/Enums/EScanActions.cs
+++ b/EthScanNet.Lib/Enums/EScanActions.cs
@@ -11,7 +11,9 @@ namespace EthScanNet.Lib.Enums
         public static readonly EScanActions TokenSupply = new("TokenSupply");
         public static readonly EScanActions TokenCirculatingSupply = new( "TokenCSupply");
         public static readonly EScanActions TokenBalance = new( "TokenBalance");
-        
+        public static readonly EScanActions TXERC20Token = new("TokenTx");
+
+
         public static readonly EScanActions GasEstimate = new("GasEstimate");
         public static readonly EScanActions GasTracker = new("GasTracker");
 

--- a/EthScanNet.Lib/Models/ApiRequests/Accounts/EScanGetERC20TokenTransferEvents.cs
+++ b/EthScanNet.Lib/Models/ApiRequests/Accounts/EScanGetERC20TokenTransferEvents.cs
@@ -1,0 +1,19 @@
+﻿using EthScanNet.Lib.Enums;
+using EthScanNet.Lib.Models.ApiResponses.Accounts;
+using EthScanNet.Lib.Models.EScan;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EthScanNet.Lib.Models.ApiRequests.Accounts
+{
+    internal class EScanGetERC20TokenTransferEvents: EScanAccountRequest
+    {
+        public EScanGetERC20TokenTransferEvents(EScanAddress address, EScanClient eScanClient)
+           : base(address, eScanClient, EScanModules.Account, EScanActions.TXERC20Token, typeof(EScanERC20TokenTransferEvents))
+        {
+        }
+    }
+}

--- a/EthScanNet.Lib/Models/ApiResponses/Accounts/EScanERC20TokenTransferEvents.cs
+++ b/EthScanNet.Lib/Models/ApiResponses/Accounts/EScanERC20TokenTransferEvents.cs
@@ -1,0 +1,16 @@
+﻿using EthScanNet.Lib.Models.ApiResponses.Accounts.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EthScanNet.Lib.Models.ApiResponses.Accounts
+{
+    public class EScanERC20TokenTransferEvents : EScanResponse
+    {
+        [JsonProperty("result")]
+        public List<EScanTokenTransferEvent> ERC20TokenTransferEvents { get; set; }
+    }
+}

--- a/EthScanNet.Test/EtherscanDemo.cs
+++ b/EthScanNet.Test/EtherscanDemo.cs
@@ -52,6 +52,9 @@ namespace EthScanNet.Test
             EScanTokenTransferEvents apiTokenTransferEvents = await client.Accounts.GetTokenEvents(new("0xf09f5e21f86692c614d2d7b47e3b9729dc1c436f"));
             Console.WriteLine("GetTokenEvents: " + apiTokenTransferEvents.Message);
             Console.WriteLine("Account test complete");
+            EScanERC20TokenTransferEvents apiERC20TokenTransferEvents = await client.Accounts.GetERC20TokenEvents(new("0xf09f5e21f86692c614d2d7b47e3b9729dc1c436f"));
+            Console.WriteLine("GetTokenEvents: " + apiTokenTransferEvents.Message);
+            Console.WriteLine("Account test complete");
         }
 
         private async Task RunTokenCommandsAsync(EScanClient client)


### PR DESCRIPTION
Hey,

I have been using your library and noticed that you didn't have anyway of pulling ERC20 tokens directly from the wallet. In the official documentation you can find this endpoint:

https://docs.etherscan.io/api-endpoints/accounts#get-a-list-of-erc20-token-transfer-events-by-address


I went ahead and added the endpoint request to this library.  Please review and merge if you find it acceptable 


 I'll probably end up doing the same for getting BEP-20 Tokens from the bscscan net. 

